### PR TITLE
LPS-129043 Use HubSpot API key to identify conversations

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/util/HubspotConnectionUtil.java
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/util/HubspotConnectionUtil.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.click.to.chat.web.internal.util;
+
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.util.ContentTypes;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Alejo Ceballos
+ */
+public class HubspotConnectionUtil {
+
+	public static String fetchToken(User user, String hubSpotApiKey) {
+		try {
+			URL url = new URL(
+				"https://api.hubspot.com/conversations/v3" +
+					"/visitor-identification/tokens/create?hapikey=" +
+						hubSpotApiKey);
+
+			HttpURLConnection httpURLConnection =
+				(HttpURLConnection)url.openConnection();
+			httpURLConnection.setRequestMethod(HttpMethods.POST);
+			httpURLConnection.setRequestProperty(
+				HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
+			httpURLConnection.setDoOutput(true);
+
+			try (OutputStream requestOutputStream =
+					httpURLConnection.getOutputStream()) {
+
+				JSONObject requestJSONObject = JSONUtil.put(
+					"email", user.getEmailAddress()
+				).put(
+					"firstName", user.getFirstName()
+				).put(
+					"lastName", user.getLastName()
+				);
+
+				byte[] jsonInput = requestJSONObject.toString(
+				).getBytes(
+					StandardCharsets.UTF_8
+				);
+
+				requestOutputStream.write(jsonInput, 0, jsonInput.length);
+			}
+
+			try (BufferedReader bufferedReader = new BufferedReader(
+					new InputStreamReader(
+						httpURLConnection.getInputStream(),
+						StandardCharsets.UTF_8))) {
+
+				StringBuilder responseStringBuilder = new StringBuilder();
+				String responseLine;
+
+				while ((responseLine = bufferedReader.readLine()) != null) {
+					responseStringBuilder.append(responseLine.trim());
+				}
+
+				JSONObject responseJSONObject =
+					JSONFactoryUtil.createJSONObject(
+						responseStringBuilder.toString());
+
+				return (String)responseJSONObject.get("token");
+			}
+		}
+		catch (IOException | JSONException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+
+			throw new SystemException(exception);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		HubspotConnectionUtil.class);
+
+}

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
@@ -16,7 +16,22 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<script async defer id="hs-script-loader" src="//js-na1.hs-scripts.com/<%= clickToChatChatProviderAccountId %>.js" type="text/javascript"></script>
+<%
+String[] credentials = clickToChatChatProviderAccountId.split("/");
+%>
+
+<script async defer id="hs-script-loader" src="//js-na1.hs-scripts.com/<%= credentials[0] %>.js" type="text/javascript"></script>
 
 <c:if test="<%= themeDisplay.isSignedIn() %>">
+	<script type="text/javascript">
+		window.hsConversationsSettings = {
+			loadImmediately: false,
+		};
+		window.hsConversationsSettings = {
+			identificationEmail: '<%= user.getEmailAddress() %>',
+			identificationToken:
+				'<%= HubspotConnectionUtil.fetchToken(user, credentials[1]) %>',
+		};
+		window.HubSpotConversations.widget.load();
+	</script>
 </c:if>

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/init.jsp
@@ -28,6 +28,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.click.to.chat.web.internal.configuration.ClickToChatConfiguration" %><%@
 page import="com.liferay.click.to.chat.web.internal.constants.ClickToChatConstants" %><%@
 page import="com.liferay.click.to.chat.web.internal.constants.ClickToChatWebKeys" %><%@
+page import="com.liferay.click.to.chat.web.internal.util.HubspotConnectionUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>


### PR DESCRIPTION
The provider key must be the concatenation of the Account ID (ex: 19907868) and the Active API key (ex: 66b6b4b2-d096-45a1-b25d-7dab3f332167) separated by "/" (slash).

Example:
![image](https://user-images.githubusercontent.com/6429921/115465870-9ef00b80-a205-11eb-933a-401ff6bba42d.png)

The Account ID (ex: 19907868):
![image](https://user-images.githubusercontent.com/6429921/115465641-491b6380-a205-11eb-8885-809943ae629a.png)

The Active API key (ex: 66b6b4b2-d096-45a1-b25d-7dab3f332167):
![image](https://user-images.githubusercontent.com/6429921/115465840-9566a380-a205-11eb-93d2-323ce4ea1811.png)
