### PR TITLE
LCI-4982 [AI Hub] Control batches sent from crawler to search via wrapper

### DIFF
--- a/workspaces/liferay-aihub-workspace/crawler-image/Dockerfile
+++ b/workspaces/liferay-aihub-workspace/crawler-image/Dockerfile
@@ -1,8 +1,9 @@
-FROM docker.elastic.co/integrations/crawler:0.4.2
+FROM docker.elastic.co/integrations/crawler:1.0.0
 
 USER root
 
-COPY entrypoint.sh /opt/liferay/entrypoint.sh
+COPY entrypoint.sh    /opt/liferay/entrypoint.sh
+COPY quota_wrapper.rb /opt/liferay/quota_wrapper.rb
 
 RUN chmod +x /opt/liferay/entrypoint.sh
 

--- a/workspaces/liferay-aihub-workspace/crawler-image/README.md
+++ b/workspaces/liferay-aihub-workspace/crawler-image/README.md
@@ -1,0 +1,337 @@
+# AI Hub Crawler
+
+Container image that wraps `docker.elastic.co/integrations/crawler:1.0.0` with a
+small Ruby proxy (`quota_wrapper.rb`) that enforces a per-crawl token budget
+against the Vertex AI embedding inference triggered when the crawled documents
+land in an Elasticsearch index mapped with `semantic_text`.
+
+## Why this exists
+
+The Elastic open crawler writes documents directly to Elasticsearch via the
+`_bulk` API. When the target index has a `semantic_text` field bound to a Vertex
+AI inference endpoint, ES synchronously calls Vertex to embed each chunk - so
+the crawl directly consumes the tenant's Vertex token budget, with no
+opportunity for the application layer to gate it. This image inserts a wrapper
+between the crawler and ES that counts the bulk payloads and rejects with HTTP
+429 once the budget is exhausted.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────┐
+│ Pod (one container)                       │
+│                                           │
+│   entrypoint.sh                           │
+│   ├─ spawns wrapper (background)          │
+│   ├─ tees crawler output to /tmp/crawl.log│
+│   └─ runs crawler against localhost:9200  │
+│                                           │
+│   crawler ──HTTP──> wrapper:9200          │
+│                       │                   │
+│                       │ count + 429 on quota
+│                       ▼                   │
+└───────────────────────|───────────────────┘
+                        │
+                        ▼
+                 Elasticsearch (real)
+                        │ (semantic_text mapping)
+                        ▼
+                  Vertex AI embedding
+```
+
+## Per-bulk processing
+
+1. Crawler POSTs `/<index>/_bulk` (gzipped NDJSON, up to 100 docs / 1 MB) to the
+   wrapper on `localhost:9200`.
+2. Wrapper decompresses the body and walks the NDJSON, summing doc-body bytes.
+3. Token estimate: `bytes ÷ CHARS_PER_TOKEN × CHUNK_OVERHEAD`. Defaults are
+   `4` and `1.4`, matching the sentence-based 250-token chunks with 100-token
+   overlap that `semantic_text` uses by default.
+4. Atomic check `consumed + batch_tokens ≤ quota`:
+   - **Fits** → reserve the tokens, forward to real ES. On 2xx response,
+     increment counters. On non-2xx, refund.
+   - **Exceeds** → respond 429 `tenant quota exceeded`, **send SIGTERM to the
+     `bin/crawler crawl` process** so the Pod stops crawling pages that can't
+     be indexed.
+
+## Modes
+
+| Mode | When | What runs | Output |
+|------|------|-----------|--------|
+| **Full** | `CRAWLER_DRY_RUN=false` | Wrapper runs as HTTP server. Crawler writes to ES via the wrapper. | Per-batch FORWARDED / QUOTA_EXHAUSTED logs + final report. |
+| **Dry-run** | `CRAWLER_DRY_RUN=true` *(default)* | Crawler writes to `/tmp/crawled_docs` (file sink). Wrapper is **not** started during the crawl; after the crawler finishes, the wrapper runs once with `--post-process` to inspect the output directory. | A final report with `estimated_consumed` and `would_exceed_quota`. |
+
+## Environment variables
+
+### Required in every run
+
+| Variable | Description |
+|---|---|
+| `CRAWLER_DOMAIN_URL` | Domain limit for the crawl. |
+| `CRAWLER_SEED_URL` | Starting URL. |
+| `CRAWLER_OUTPUT_INDEX` | Target index. In full mode the crawler writes here; in dry-run it's informational. |
+
+### Required when `CRAWLER_DRY_RUN=false`
+
+| Variable | Description |
+|---|---|
+| `ELASTICSEARCH_HOST` | ES hostname; accepts plain hostname or `http(s)://hostname`. |
+| `ELASTICSEARCH_PORT` | ES port (typically 9200). |
+| `TENANT_AVAILABLE_QUOTA_TOKENS` | Tokens this crawl may consume. **Computed by the caller** as `tenant_quota_limit - tenant_quota_used` before the Job is created. The wrapper has no view of current usage and trusts this value. |
+
+### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `CRAWLER_DRY_RUN` | `true` | Set to `false` for full ES integration. |
+| `TENANT_ID` | `unknown` | Echoed in logs and the final report. |
+| `CHARS_PER_TOKEN` | `4` | Conversion factor for English. Increase for multi-byte / non-Latin scripts. |
+| `CHUNK_OVERHEAD` | `1.4` | Multiplier for chunk overlap in `semantic_text` chunking. |
+| `WRAPPER_PORT` | `9200` | Port the wrapper listens on (container-local). |
+| `CRAWLER_LOG_FILE` | `/tmp/crawl.log` | File the entrypoint tees crawler output to. |
+| `DRY_RUN_OUTPUT_DIR` | `/tmp/crawled_docs` | Where the crawler writes files in dry-run. |
+| `WRAPPER_REPORT_FILE` | `/tmp/wrapper-report.json` | The wrapper persists its final report here for the entrypoint to read. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Crawler completed and no batch was rejected. |
+| `1` | Bootstrap failure (wrapper didn't start within 15 s, config invalid, etc.). |
+| `2` | **Quota exhausted**: in full mode any batch was rejected; in dry-run the estimate would have exceeded the quota. The caller (Spring Boot dispatcher) should treat this as a definitive quota failure - retrying without raising the quota will produce the same result and re-consume Vertex tokens. |
+
+The `BackoffLimit` of the Job should be `0`: retries on a quota-exhausted Pod
+just re-run the crawl and re-bill Vertex.
+
+## Final report
+
+Both modes emit one **single-line JSON** to stdout, parsed automatically into
+`jsonPayload` by Cloud Logging. The same JSON is written to
+`/tmp/wrapper-report.json` so the entrypoint can read it after signaling the
+wrapper.
+
+Identify the line by `event == "crawler_final_report"`.
+
+### Full mode — success
+
+```json
+{
+  "event": "crawler_final_report",
+  "mode": "server",
+  "tenant_id": "tenant-abc",
+  "timestamp": "2026-05-22T20:59:27Z",
+  "tokens": {
+    "consumed": 926693,
+    "quota": 10000000,
+    "remaining": 9073307,
+    "bulks_forwarded": 4,
+    "bulks_rejected": 0,
+    "docs_forwarded": 391,
+    "duration_seconds": 183
+  },
+  "crawler": {
+    "crawl_id": "6a10c3023d6731bd8f1a154f",
+    "result": "success",
+    "pages_visited": 774,
+    "urls_allowed": 773,
+    "already_seen": 10077,
+    "domain_filter": 15892,
+    "crawl_duration_seconds": 172.0,
+    "crawling_time_seconds": 199.283,
+    "avg_response_time_seconds": 0.2574,
+    "docs_upserted": 391,
+    "docs_upserted_bytes": 2647700,
+    "docs_failed": 0,
+    "docs_failed_bytes": 0
+  }
+}
+```
+
+### Full mode — quota exhausted
+
+Same shape, with `bulks_rejected > 0` and `docs_forwarded < pages_visited`.
+The Pod exits with code 2.
+
+```json
+{
+  "tokens": {
+    "consumed": 712271,
+    "quota": 750000,
+    "remaining": 37729,
+    "bulks_forwarded": 3,
+    "bulks_rejected": 1,
+    "docs_forwarded": 300,
+    "duration_seconds": 205
+  }
+}
+```
+
+### Dry-run
+
+```json
+{
+  "event": "crawler_final_report",
+  "mode": "post_process",
+  "tenant_id": "tenant-abc",
+  "timestamp": "2026-05-22T15:33:09Z",
+  "tokens": {
+    "estimated_consumed": 6019144,
+    "quota": 2000000,
+    "remaining": -4019144,
+    "would_exceed_quota": true
+  },
+  "output": {
+    "docs_written": 1221,
+    "bytes_written": 17197557,
+    "output_dir": "/tmp/crawled_docs"
+  },
+  "crawler": {
+    "crawl_id": "abc123",
+    "result": "success",
+    "pages_visited": 3182,
+    "...": "..."
+  }
+}
+```
+
+Negative `remaining` is the deficit; positive is the headroom.
+
+## Consumer pattern (Spring Boot dispatcher)
+
+After the Pod terminates:
+
+1. Read the Pod logs (or query Cloud Logging on `jsonPayload.event`).
+2. Find the line where `event == "crawler_final_report"`.
+3. Branch on `mode`:
+   - **`server`**: charge `tokens.consumed` to the tenant's quota in CloudSQL.
+     If the Pod exited 2 (`tokens.bulks_rejected > 0`), surface "crawl
+     interrupted by quota" to the admin.
+   - **`post_process`**: no real Vertex consumption. If `would_exceed_quota`
+     is true, surface it without debiting.
+
+## Required ES setup
+
+The crawler **auto-creates** the target index with a default mapping if it
+doesn't exist - **and the auto-created index has no `semantic_text` field**,
+so no embedding happens. To exercise the inference path, the caller must
+pre-create the index:
+
+```http
+PUT /<index_name>
+{
+  "settings": {
+    "index": {
+      "default_pipeline": "liferay-ai-hub-crawl-result-ingestion-pipeline"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "properties": {
+      "body":  {"type": "text"},
+      "title": {"type": "text"},
+      "url":   {"type": "keyword"},
+      "last_crawled_at": {"type": "date"},
+      "text_embedding": {
+        "type": "semantic_text",
+        "inference_id": "google-vertex-ai-gemini-embedding-001"
+      }
+    }
+  }
+}
+```
+
+The ingest pipeline composes `text_embedding` from `title` + `body`, which is
+what triggers the Vertex inference call.
+
+## Usage in a Job manifest
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aihub-crawler-<random>
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: crawler
+          image: europe-west3-docker.pkg.dev/internal-assets-prd/ai-hub/aihub-crawler:<tag>
+          env:
+            - {name: CRAWLER_DRY_RUN,               value: "false"}
+            - {name: CRAWLER_DOMAIN_URL,            value: "https://example.com"}
+            - {name: CRAWLER_SEED_URL,              value: "https://example.com"}
+            - {name: CRAWLER_OUTPUT_INDEX,          value: "liferay-<companyId>-ai-hub-...-crawl-results-<uuid>"}
+            - {name: ELASTICSEARCH_HOST,            value: "http://search-es-http.<ns>.svc.cluster.local"}
+            - {name: ELASTICSEARCH_PORT,            value: "9200"}
+            - {name: TENANT_AVAILABLE_QUOTA_TOKENS, value: "1000000"}
+            - {name: TENANT_ID,                     value: "tenant-abc"}
+```
+
+## Behavioral notes
+
+- **Quota enforcement is per-bulk, all-or-nothing**: a batch that wouldn't
+  fit entirely is rejected entirely. Combined with the 100-doc / 1-MB bulk
+  cap, "wasted" quota at the end is at most a single batch worth (~250k
+  tokens).
+- **Token estimate is approximate**: `bytes / 4 × 1.4` lands within ~10-20%
+  of real Vertex usage for English text. Multi-byte scripts, HTML-heavy
+  pages, and non-default chunking will skew it. Replace with a real
+  tokenizer (e.g. `jtokkit`) or call Vertex's `countTokens` if precision
+  matters.
+- **The wrapper kills the crawler on quota exhaustion**: matches any process
+  in the Pod's PID namespace whose `cmdline` contains both `bin/crawler` and
+  `crawl`. Assumes there's only one such process.
+- **Crawler exit code is unreliable** for ES-side failures: it often exits 0
+  even when bulks were rejected. The entrypoint normalizes this to exit 2
+  whenever `tokens.bulks_rejected > 0`.
+- **Cosmetic `Errno::ECONNRESET` in the log**: emitted by WEBrick when the
+  crawler is killed mid-request. The reject was already processed and the
+  report was emitted; ignore.
+
+## Limitations
+
+- Only `_bulk` traffic is metered. Other endpoints (search, `_inference`,
+  `_cluster/health`, etc.) are proxied raw.
+- A single huge document in the middle of a crawl can push a single batch
+  past the quota. The whole batch is then rejected.
+- The wrapper's PID namespace assumption (one crawler process) is reasonable
+  inside a Job-spawned Pod but doesn't hold in arbitrary containers.
+
+## Local development
+
+```bash
+# Build
+docker build -t aihub-crawler:local .
+
+# Port-forward ES (in another terminal)
+kubectl -n <es-namespace> port-forward svc/search-es-http 9201:9200
+
+# Full mode against the port-forwarded ES
+docker run --rm \
+  --network=host \
+  --user 1000 \
+  -e CRAWLER_DRY_RUN=false \
+  -e CRAWLER_DOMAIN_URL=https://parksaustralia.gov.au \
+  -e CRAWLER_SEED_URL=https://parksaustralia.gov.au \
+  -e CRAWLER_OUTPUT_INDEX=crawler-test \
+  -e ELASTICSEARCH_HOST=localhost \
+  -e ELASTICSEARCH_PORT=9201 \
+  -e TENANT_AVAILABLE_QUOTA_TOKENS=1000000 \
+  -e TENANT_ID=test \
+  aihub-crawler:local
+
+# Dry-run (no ES needed)
+docker run --rm \
+  --user 1000 \
+  -e CRAWLER_DOMAIN_URL=https://parksaustralia.gov.au \
+  -e CRAWLER_SEED_URL=https://parksaustralia.gov.au \
+  -e CRAWLER_OUTPUT_INDEX=crawler-test \
+  -e TENANT_AVAILABLE_QUOTA_TOKENS=1000000 \
+  aihub-crawler:local
+
+# Pretty-print the final report from a run
+docker run ... 2>&1 | grep '^{"event"' | jq
+```

--- a/workspaces/liferay-aihub-workspace/crawler-image/entrypoint.sh
+++ b/workspaces/liferay-aihub-workspace/crawler-image/entrypoint.sh
@@ -1,17 +1,60 @@
 #!/bin/bash
 set -uo pipefail
+# See README.md for env vars, modes, exit codes, and report format.
 
+: "${CRAWLER_DRY_RUN:=true}"
 : "${CRAWLER_DOMAIN_URL:?missing CRAWLER_DOMAIN_URL}"
-: "${CRAWLER_OUTPUT_INDEX:?missing CRAWLER_OUTPUT_INDEX}"
 : "${CRAWLER_SEED_URL:?missing CRAWLER_SEED_URL}"
-: "${ELASTICSEARCH_HOST:?missing ELASTICSEARCH_HOST}"
-: "${ELASTICSEARCH_PORT:?missing ELASTICSEARCH_PORT}"
+: "${CRAWLER_OUTPUT_INDEX:?missing CRAWLER_OUTPUT_INDEX}"
+
+if [[ "${CRAWLER_DRY_RUN}" != "true" ]]; then
+	: "${ELASTICSEARCH_HOST:?missing ELASTICSEARCH_HOST}"
+	: "${ELASTICSEARCH_PORT:?missing ELASTICSEARCH_PORT}"
+	: "${TENANT_AVAILABLE_QUOTA_TOKENS:?missing TENANT_AVAILABLE_QUOTA_TOKENS}"
+fi
+: "${TENANT_ID:=unknown}"
 
 log() {
 	echo "[$(date -Iseconds)] $*"
 }
 
-cat > /tmp/crawl.yml <<EOF
+if [[ "${CRAWLER_DRY_RUN}" == "true" ]]; then
+	log "DRY RUN: crawler writes to disk; wrapper not started"
+
+	cat > /tmp/crawl.yml <<EOF
+domains:
+    -   url: "${CRAWLER_DOMAIN_URL}"
+        seed_urls:
+            -   "${CRAWLER_SEED_URL}"
+
+output_sink: file
+output_dir: /tmp/crawled_docs
+EOF
+else
+	log "Starting quota wrapper (tenant=${TENANT_ID}, available_quota=${TENANT_AVAILABLE_QUOTA_TOKENS})"
+	ELASTICSEARCH_HOST_REAL="${ELASTICSEARCH_HOST}" \
+	ELASTICSEARCH_PORT_REAL="${ELASTICSEARCH_PORT}" \
+	TENANT_AVAILABLE_QUOTA_TOKENS="${TENANT_AVAILABLE_QUOTA_TOKENS}" \
+	TENANT_ID="${TENANT_ID}" \
+	ruby /opt/liferay/quota_wrapper.rb &
+	WRAPPER_PID=$!
+
+	# Safety net: stop the wrapper if the script exits unexpectedly.
+	trap 'kill -TERM ${WRAPPER_PID} 2>/dev/null; wait ${WRAPPER_PID} 2>/dev/null' EXIT
+
+	for i in $(seq 1 30); do
+		if (echo > /dev/tcp/127.0.0.1/9200) 2>/dev/null; then
+			log "Wrapper ready"
+			break
+		fi
+		if [ "$i" -eq 30 ]; then
+			log "Wrapper failed to start within 15s"
+			exit 1
+		fi
+		sleep 0.5
+	done
+
+	cat > /tmp/crawl.yml <<EOF
 domains:
     -   url: "${CRAWLER_DOMAIN_URL}"
         seed_urls:
@@ -24,16 +67,46 @@ elasticsearch:
     bulk_api:
         max_items: 100
         max_size_bytes: 1048576
-    host: "${ELASTICSEARCH_HOST}"
+    host: "localhost"
     pipeline_enabled: false
-    port: ${ELASTICSEARCH_PORT}
+    port: 9200
 EOF
+fi
 
-log "Starting crawler with seed=${CRAWLER_SEED_URL} index=${CRAWLER_OUTPUT_INDEX}"
+log "Starting crawler with seed=${CRAWLER_SEED_URL} index=${CRAWLER_OUTPUT_INDEX} dry_run=${CRAWLER_DRY_RUN}"
 
-bundle exec bin/crawler crawl /tmp/crawl.yml
-exit_code=$?
+# Tee so the wrapper can parse "Crawl Stats" / "Ingestion Stats" on shutdown.
+bundle exec bin/crawler crawl /tmp/crawl.yml 2>&1 | tee /tmp/crawl.log
+exit_code=${PIPESTATUS[0]}
 
 log "Crawler finished with exit code ${exit_code}"
+
+if [[ "${CRAWLER_DRY_RUN}" == "true" ]]; then
+	log "Running post-process to estimate token consumption"
+	TENANT_ID="${TENANT_ID}" \
+	TENANT_AVAILABLE_QUOTA_TOKENS="${TENANT_AVAILABLE_QUOTA_TOKENS:-}" \
+	ruby /opt/liferay/quota_wrapper.rb --post-process
+	post_process_exit=$?
+
+	# Only override on crawler success - never mask a real crawler failure.
+	if [[ "${exit_code}" -eq 0 && "${post_process_exit}" -ne 0 ]]; then
+		log "Post-process flagged would_exceed_quota; Job will fail"
+		exit_code=${post_process_exit}
+	fi
+else
+	# Signal the wrapper and wait so the report file is written before we read it.
+	kill -TERM ${WRAPPER_PID} 2>/dev/null
+	wait ${WRAPPER_PID} 2>/dev/null
+
+	# The crawler's own exit code doesn't reflect bulk rejections; force exit 2
+	# if any batch was rejected so the K8s Job is marked Failed.
+	if [ -f /tmp/wrapper-report.json ]; then
+		rejected=$(ruby -rjson -e 'puts JSON.parse(File.read("/tmp/wrapper-report.json")).dig("tokens","bulks_rejected").to_i' 2>/dev/null)
+		if [ "${rejected:-0}" -gt 0 ]; then
+			log "Wrapper rejected ${rejected} batches (quota exhausted); Job will fail (exit 2)"
+			exit_code=2
+		fi
+	fi
+fi
 
 exit ${exit_code}

--- a/workspaces/liferay-aihub-workspace/crawler-image/quota_wrapper.rb
+++ b/workspaces/liferay-aihub-workspace/crawler-image/quota_wrapper.rb
@@ -1,0 +1,340 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# See README.md for documentation on modes, env vars, exit codes, and reports.
+
+require 'webrick'
+require 'net/http'
+require 'json'
+require 'logger'
+require 'stringio'
+require 'time'
+require 'zlib'
+
+QUOTA_STR        = ENV.fetch('TENANT_AVAILABLE_QUOTA_TOKENS', '')
+QUOTA            = QUOTA_STR.empty? ? nil : Integer(QUOTA_STR)
+# Accept "host" or "http(s)://host"; extract bare hostname + TLS flag.
+_es_host_raw     = ENV.fetch('ELASTICSEARCH_HOST_REAL', '')
+ES_USE_TLS       = _es_host_raw.start_with?('https://')
+ES_HOST          = _es_host_raw.sub(%r{\Ahttps?://}, '')
+ES_PORT_STR      = ENV.fetch('ELASTICSEARCH_PORT_REAL', '')
+ES_PORT          = ES_PORT_STR.empty? ? nil : Integer(ES_PORT_STR)
+TENANT_ID        = ENV.fetch('TENANT_ID', 'unknown')
+WRAPPER_PORT     = Integer(ENV.fetch('WRAPPER_PORT', '9200'))
+CHARS_PER_TOKEN  = Integer(ENV.fetch('CHARS_PER_TOKEN', '4'))
+CHUNK_OVERHEAD   = Float(ENV.fetch('CHUNK_OVERHEAD', '1.4'))
+CRAWLER_LOG_FILE = ENV.fetch('CRAWLER_LOG_FILE', '/tmp/crawl.log')
+DRY_RUN_OUTPUT_DIR = ENV.fetch('DRY_RUN_OUTPUT_DIR', '/tmp/crawled_docs')
+WRAPPER_REPORT_FILE = ENV.fetch('WRAPPER_REPORT_FILE', '/tmp/wrapper-report.json')
+
+EXCLUDED_HEADERS = %w[host content-length transfer-encoding connection].freeze
+
+LOG = Logger.new($stdout)
+LOG.formatter = proc { |_sev, ts, _, msg| "#{ts.iso8601} [wrapper] #{msg}\n" }
+
+$counter_mutex      = Mutex.new
+$consumed_tokens    = 0
+$rejected_batches   = 0
+$bulks_forwarded    = 0
+$docs_forwarded     = 0
+$start_time         = Time.now
+$crawler_terminated = false
+
+# Send SIGTERM to any `bin/crawler crawl` process in the Pod's PID namespace.
+# Idempotent. Triggered when quota is exhausted to stop wasted work.
+def terminate_crawler_once
+  return if $crawler_terminated
+  $crawler_terminated = true
+  killed = []
+  Dir.glob('/proc/[0-9]*').each do |proc_dir|
+    cmdline = (File.read(File.join(proc_dir, 'cmdline')) rescue '')
+    next unless cmdline.include?('bin/crawler') && cmdline.include?('crawl')
+    pid = File.basename(proc_dir).to_i
+    next if pid == Process.pid
+    begin
+      Process.kill('TERM', pid)
+      killed << pid
+    rescue StandardError => e
+      LOG.warn("could not SIGTERM crawler pid=#{pid}: #{e.class}: #{e.message}")
+    end
+  end
+  LOG.info("quota exhausted; sent SIGTERM to crawler pid(s)=#{killed.inspect}") unless killed.empty?
+end
+
+def reserve_quota(batch_tokens)
+  $counter_mutex.synchronize do
+    if $consumed_tokens + batch_tokens > QUOTA
+      $rejected_batches += 1
+      return false
+    end
+    $consumed_tokens += batch_tokens
+    true
+  end
+end
+
+def refund_quota(batch_tokens)
+  $counter_mutex.synchronize { $consumed_tokens -= batch_tokens }
+end
+
+# Walks the bulk NDJSON, summing doc-body bytes.
+# Returns [estimated_tokens, doc_count].
+def parse_bulk(bulk_body)
+  chars = 0
+  docs  = 0
+  lines = bulk_body.split("\n")
+  i = 0
+  while i < lines.length
+    begin
+      action = JSON.parse(lines[i])
+    rescue StandardError
+      i += 1
+      next
+    end
+    if action.key?('delete')
+      i += 1
+      next
+    end
+    i += 1
+    if i < lines.length
+      chars += lines[i].bytesize
+      docs += 1
+    end
+    i += 1
+  end
+  tokens = (chars.to_f / CHARS_PER_TOKEN * CHUNK_OVERHEAD).to_i
+  [tokens, docs]
+end
+
+# Extract crawler stats from the tee'd log file.
+def parse_crawler_log
+  return {} unless File.exist?(CRAWLER_LOG_FILE)
+  content = File.read(CRAWLER_LOG_FILE)
+  out = {}
+
+  single_patterns = {
+    crawl_id:                  [/\[crawl:([a-f0-9]+)\]/,                                :string],
+    result:                    [/Finished a crawl\. Result:\s+(\w+)/,                   :string],
+    pages_visited:             [/Pages visited:\s+(\d+)/,                               :int],
+    urls_allowed:              [/URLs allowed:\s+(\d+)/,                                :int],
+    already_seen:              [/Already seen:\s+(\d+)/,                                :int],
+    domain_filter:             [/Domain filter:\s+(\d+)/,                               :int],
+    crawl_duration_seconds:    [/Crawl duration \(seconds\):\s+([\d.]+)/,               :float],
+    crawling_time_seconds:     [/Crawling time \(seconds\):\s+([\d.]+)/,                :float],
+    avg_response_time_seconds: [/Average response time \(seconds\):\s+([\d.]+)/,        :float],
+  }
+
+  single_patterns.each do |key, (pattern, type)|
+    m = content.match(pattern)
+    next unless m
+    out[key] = case type
+               when :int   then m[1].to_i
+               when :float then m[1].to_f
+               else m[1]
+               end
+  end
+
+  # Two "Volume (bytes)" lines exist (upserted + failed); pair each with its context.
+  if (m = content.match(/Documents upserted:\s+(\d+).*?Volume \(bytes\):\s+(\d+)/m))
+    out[:docs_upserted] = m[1].to_i
+    out[:docs_upserted_bytes] = m[2].to_i
+  end
+  if (m = content.match(/Number of documents that failed to index:\s+(\d+).*?Volume \(bytes\):\s+(\d+)/m))
+    out[:docs_failed] = m[1].to_i
+    out[:docs_failed_bytes] = m[2].to_i
+  end
+
+  out
+end
+
+class QuotaProxy < WEBrick::HTTPServlet::AbstractServlet
+  def do_GET(req, res);    handle(req, res); end
+  def do_POST(req, res);   handle(req, res); end
+  def do_PUT(req, res);    handle(req, res); end
+  def do_DELETE(req, res); handle(req, res); end
+  def do_HEAD(req, res);   handle(req, res); end
+
+  private
+
+  def handle(req, res)
+    body = req.body || ''
+
+    unless req.path.end_with?('/_bulk')
+      proxy_to_es(req, body, res)
+      return
+    end
+
+    # elastic-transport gzips bulk bodies; decompress for parsing, forward as-is.
+    encoding = (req['Content-Encoding'] || '').downcase
+    parse_body = if encoding == 'gzip'
+      begin
+        Zlib::GzipReader.new(StringIO.new(body)).read
+      rescue StandardError => e
+        LOG.warn("failed to gunzip bulk body: #{e.class}: #{e.message}")
+        ''
+      end
+    else
+      body
+    end
+
+    batch_tokens, batch_docs = parse_bulk(parse_body)
+    unless reserve_quota(batch_tokens)
+      LOG.warn(
+        "QUOTA_EXHAUSTED tenant=#{TENANT_ID} consumed=#{$consumed_tokens} " \
+        "attempted=#{batch_tokens} quota=#{QUOTA}"
+      )
+      res.status = 429
+      res['Content-Type'] = 'application/json'
+      res.body = JSON.dump(
+        error: 'tenant quota exceeded',
+        tenant_id: TENANT_ID,
+        consumed_tokens: $consumed_tokens,
+        quota_tokens: QUOTA,
+      )
+      terminate_crawler_once
+      return
+    end
+
+    status = proxy_to_es(req, body, res)
+    if (200..299).include?(status)
+      $counter_mutex.synchronize do
+        $bulks_forwarded += 1
+        $docs_forwarded += batch_docs
+      end
+      LOG.info(
+        "FORWARDED tenant=#{TENANT_ID} batch_tokens=#{batch_tokens} " \
+        "batch_docs=#{batch_docs} consumed=#{$consumed_tokens}/#{QUOTA}"
+      )
+    else
+      refund_quota(batch_tokens)
+    end
+  end
+
+  # HEAD requires resp_body_permitted=false; otherwise Net::HTTP blocks
+  # waiting for a body that never comes.
+  METHOD_FLAGS = {
+    'GET'    => [false, true],
+    'HEAD'   => [false, false],
+    'POST'   => [true,  true],
+    'PUT'    => [true,  true],
+    'DELETE' => [true,  true],
+    'PATCH'  => [true,  true],
+  }.freeze
+
+  def proxy_to_es(req, body, res)
+    method = req.request_method.upcase
+    req_body_perm, resp_body_perm = METHOD_FLAGS.fetch(method, [true, true])
+    Net::HTTP.start(ES_HOST, ES_PORT, use_ssl: ES_USE_TLS, open_timeout: 10, read_timeout: 60) do |http|
+      es_req = Net::HTTPGenericRequest.new(method, req_body_perm, resp_body_perm, req.path)
+      req.header.each do |k, v|
+        next if EXCLUDED_HEADERS.include?(k.downcase)
+        es_req[k] = v.first
+      end
+      es_req.body = body if req_body_perm
+      es_resp = http.request(es_req)
+      res.status = es_resp.code.to_i
+      es_resp.each_header do |k, v|
+        next if EXCLUDED_HEADERS.include?(k.downcase)
+        res[k] = v
+      end
+      res.body = es_resp.body || ''
+      return res.status
+    end
+  rescue StandardError => e
+    LOG.error("proxy failed: #{e.class}: #{e.message}")
+    res.status = 502
+    res.body = ''
+    502
+  end
+end
+
+def emit_final_report
+  report = {
+    event:     'crawler_final_report',
+    mode:      'server',
+    tenant_id: TENANT_ID,
+    timestamp: Time.now.utc.iso8601,
+    tokens: {
+      consumed:         $consumed_tokens,
+      quota:            QUOTA,
+      remaining:        QUOTA.nil? ? nil : (QUOTA - $consumed_tokens),
+      bulks_forwarded:  $bulks_forwarded,
+      bulks_rejected:   $rejected_batches,
+      docs_forwarded:   $docs_forwarded,
+      duration_seconds: (Time.now - $start_time).round,
+    },
+    crawler: parse_crawler_log,
+  }
+  json = JSON.dump(report)
+  $stdout.puts json
+  $stdout.flush
+  File.write(WRAPPER_REPORT_FILE, json) rescue nil
+end
+
+def measure_output_dir
+  return [0, 0] unless File.directory?(DRY_RUN_OUTPUT_DIR)
+  bytes = 0
+  count = 0
+  Dir.glob(File.join(DRY_RUN_OUTPUT_DIR, '**', '*')).each do |path|
+    next unless File.file?(path)
+    bytes += File.size(path)
+    count += 1
+  end
+  [bytes, count]
+end
+
+def emit_post_process_report
+  crawler_stats = parse_crawler_log
+  bytes, docs_count = measure_output_dir
+  estimated_tokens = (bytes.to_f / CHARS_PER_TOKEN * CHUNK_OVERHEAD).to_i
+
+  report = {
+    event:     'crawler_final_report',
+    mode:      'post_process',
+    tenant_id: TENANT_ID,
+    timestamp: Time.now.utc.iso8601,
+    tokens: {
+      estimated_consumed: estimated_tokens,
+      quota:              QUOTA,
+      remaining:          QUOTA.nil? ? nil : (QUOTA - estimated_tokens),
+      would_exceed_quota: QUOTA.nil? ? nil : (estimated_tokens > QUOTA),
+    },
+    output: {
+      docs_written:  docs_count,
+      bytes_written: bytes,
+      output_dir:    DRY_RUN_OUTPUT_DIR,
+    },
+    crawler: crawler_stats,
+  }
+  $stdout.puts JSON.dump(report)
+  $stdout.flush
+  report[:tokens][:would_exceed_quota] == true
+end
+
+if ARGV.include?('--post-process')
+  exit(emit_post_process_report ? 2 : 0)
+end
+
+abort 'TENANT_AVAILABLE_QUOTA_TOKENS is required in server mode' if QUOTA.nil?
+abort 'ELASTICSEARCH_HOST_REAL and ELASTICSEARCH_PORT_REAL are required in server mode' if ES_HOST.empty? || ES_PORT.nil?
+
+LOG.info(
+  "starting wrapper port=#{WRAPPER_PORT} tenant=#{TENANT_ID} quota=#{QUOTA} " \
+  "es_real=#{ES_HOST}:#{ES_PORT}"
+)
+
+server = WEBrick::HTTPServer.new(
+  BindAddress: '127.0.0.1',
+  Port: WRAPPER_PORT,
+  Logger: WEBrick::Log.new($stdout, WEBrick::Log::WARN),
+  AccessLog: [],
+)
+server.mount('/', QuotaProxy)
+
+# server.shutdown (instead of exit) avoids a "FATAL SystemExit" trace.
+%w[TERM INT].each do |sig|
+  Signal.trap(sig) do
+    emit_final_report
+    server.shutdown
+  end
+end
+
+server.start


### PR DESCRIPTION
To control the tentant’s quota we can estimate the number of used tokens on the embeding with the number of characters to be sent to the search instance and receive the remaining available tokens from the springboot app via env var.

A wrapper will be created to control batches and exit gracefully if necessary.